### PR TITLE
Updating handling of sample priority extraction

### DIFF
--- a/propagator_test.go
+++ b/propagator_test.go
@@ -53,11 +53,8 @@ func TestExtractMultiple(t *testing.T) {
 		},
 		{
 			ddTraceIDSmall, ddParentIDSmall, "",
-			trace.SpanContextConfig{
-				TraceID: traceIDSmall,
-				SpanID:  spanIDSmall,
-			},
-			nil,
+			trace.SpanContextConfig{},
+			errInvalidSamplingPriorityHeader,
 		},
 		{
 			"", ddParentID, "",
@@ -78,6 +75,28 @@ func TestExtractMultiple(t *testing.T) {
 			ddTraceID, "0000000000000000000", "",
 			trace.SpanContextConfig{},
 			errInvalidSpanIDHeader,
+		},
+		{
+			ddTraceID, ddParentID, "foo",
+			trace.SpanContextConfig{},
+			errInvalidSamplingPriorityHeader,
+		},
+		{
+			ddTraceID, ddParentID, "2",
+			trace.SpanContextConfig{
+				TraceID:    traceID,
+				SpanID:     spanID,
+				TraceFlags: trace.FlagsSampled,
+			},
+			nil,
+		},
+		{
+			ddTraceID, ddParentID, "-1",
+			trace.SpanContextConfig{
+				TraceID:    traceID,
+				SpanID:     spanID,
+			},
+			nil,
 		},
 	}
 


### PR DESCRIPTION
This change updates the sample priority extraction logic to match what is provided in Datadog's SDKs.  I.e. any positive integer value is treated as a true value, any 0 or negative integer value is treated as a false value. Non-integer values cause context extraction to fail with an error.

This partially addresses #17 in that extraction will now work correctly for values > 1; it does not propagate the non 0/1 values to any outgoing trace context.